### PR TITLE
Convert to Python 3 and fix broadcast reception

### DIFF
--- a/extractV3.py
+++ b/extractV3.py
@@ -8,30 +8,28 @@ import struct
 import socket
 import sys
 import os
-import datetime
-import re
 import signal
 
 ########## CHANGE TO YOUR PARAMS ##########
 switcherIP = "0.0.0.0" 
 device_id = "000000"
 device_pass = "00000000"
-UDP_IP = "0.0.0.0"
-UDP_PORT = 20002
+UDP_IP = ""
+UDP_PORT = 10002
 sCommand = "0"
 ########## DO NOT CHANGE BYOND THIS LINE  ##########
 
 if len(sys.argv) != 2:
-	print "\r\n********* Usage: ./" + sys.argv[0] + " phone_id *********\r\n"
+	print ("\r\n********* Usage: ./" + sys.argv[0] + " phone_id *********\r\n")
 	sys.exit()
 
 phone_id = sys.argv[1]
 
 def crcSignFullPacketComKey(pData, pKey):
-	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(pData), 0x1021)))
+	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(pData), 0x1021))).decode()
 	pData = pData + crc[6:8] + crc[4:6]
-	crc = crc[6:8] + crc[4:6] + ba.hexlify( pKey )
-	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(crc), 0x1021)))
+	crc = crc[6:8] + crc[4:6] + ba.hexlify(pKey.encode() if isinstance(pKey, str) else pKey).decode()
+	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(crc), 0x1021))).decode()
 	pData = pData + crc[6:8] + crc[4:6]
 	return pData
 
@@ -45,7 +43,7 @@ def sTimer(sMinutes):
 
 
 def sigint_handler(signum, frame):
-	print '[+] Stopped...'
+	print ('[+] Stopped...')
 	sys.exit(0)
 
  
@@ -57,72 +55,76 @@ pKey = "00000000000000000000000000000000"
 ############# DO NOT CHANGE ############
 
 
-print """
+print ("""
 		=========================================================
 	   	+ Switcher V2 Python                                    +
 	 	+ Reverse Engineering and Coding By:                    +
 	 	+ Aviad Golan (@AviadGolan) and Shai Rod (@NightRang3r) +
 	 	=========================================================
-	 """
+	 """)
 	
 try:
-	sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
+	sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+	sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+	sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 	sock.bind((UDP_IP, UDP_PORT))
 	while True:
-		print "[*] Waiting for broadcast from Switcher device..."
-		data, addr = sock.recvfrom(1024) 
-		if ba.hexlify(data)[0:4] != "fef0" and len(data) != 165:
-				print "[!] Not a switcher broadcast message!"
+		print ("[*] Waiting for broadcast from Switcher device...")
+		data, addr = sock.recvfrom(1024)
+		print(f"[DEBUG] Received {len(data)} bytes from {addr[0]}")
+		if ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165:
+				print ("[!] Not a switcher broadcast message!")
+				continue
 		else:
-			b = ba.hexlify(data)[152:160]
+			b = ba.hexlify(data)[152:160].decode()
 			ip_addr = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
 			switcherIP = socket.inet_ntoa(struct.pack("<L", ip_addr))
-			device_id = ba.hexlify(data)[36:42]
-			print "[+] Device ID: " + device_id
+			device_id = ba.hexlify(data)[36:42].decode()
+			print ("[+] Device ID: " + device_id)
 			break
 
 except Exception as e:
 	print("[!] Something went wrong...")
-	print "[!] " + str(e)
+	print ("[!] " + str(e))
 
 try:
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	s.connect((switcherIP, 9957)) 
 	
-	data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
+	data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS().decode() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
 	data = crcSignFullPacketComKey(data, pKey)
 	print ("[*] Sending Login Packet to Switcher...")
 	s.send(ba.unhexlify(data))
 	res = s.recv(1024)
-	pSession2 = ba.hexlify(res)[16:24]
+	pSession2 = ba.hexlify(res)[16:24].decode()
 	if not pSession2:
 		s.close()
 		print ("[!] Operation failed, Could not acquire SessionID, Please try again...")
 		sys.exit()
 	else:
-		data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00"
+		data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
 		print ("[+] Received SessionID: " + pSession2)	
-		print "[+] Using Phone ID: " + phone_id
+		print ("[+] Using Phone ID: " + phone_id)
 		brute_start = time.time()			
 		for i in range(0, 9999):
-			device_pass = ba.hexlify("%04d"%(i))
+			device_pass = ba.hexlify(b"%04d"%(i)).decode()
 			sys.stdout.write("\r[*] Brute forcing Device Password, Please wait:" + device_pass)
 			sys.stdout.flush()
-			data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
+			data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			if len(res) > 44 and len(res) < 60:
 				brute_end = time.time()
 				total_time= time.strftime("%H:%M:%S", time.gmtime(brute_end-brute_start))
-				print "\r\n[+] Found password in: " + total_time
-				print "[+] Switcher IP: " +  addr[0]
-				print "[+] Device ID: " + device_id
-				print "[+] Phone ID:" + phone_id
-				print "[+] Device Password: " + device_pass
+				print ("\r\n[+] Found password in: " + total_time)
+				print ("[+] Switcher IP: " +  addr[0])
+				print ("[+] Device ID: " + device_id)
+				print ("[+] Phone ID:" + phone_id)
+				print ("[+] Device Password: " + device_pass)
 				s.close()
 				file = open('switcher.txt', 'w') 
 				file.write("switcherIP = " +  '"' + addr[0] + '"\r')
@@ -130,10 +132,10 @@ try:
 				file.write("device_id = " + '"' + device_id + '"\r')
 				file.write("device_pass = " + '"' + device_pass + '"\r')
 				file.close() 
-				print "[+] Information was written to " + os.getcwd() + "/switcher.txt"
+				print ("[+] Information was written to " + os.getcwd() + "/switcher.txt")
 				sys.exit()
 except Exception as e:
 	print("[!] Something went wrong...")
-	print "[!] " + str(e)
+	print ("[!] " + str(e))
 
 

--- a/switcher.py
+++ b/switcher.py
@@ -402,7 +402,7 @@ if sys.argv[1] == "configure":
 		while True:
 			data, addr = sock.recvfrom(1024)
 			print(f"[DEBUG] Received {len(data)} bytes from {addr[0]}")
-			if (ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165) or (addr[0] != "192.168.1.1" and addr[0] != "192.168.4.1"):
+			if ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165:
 				print ("[!] Not a switcher configuration broadcast message!")
 				continue
 			else:

--- a/switcher.py
+++ b/switcher.py
@@ -1,6 +1,8 @@
 # Reverse Engineering and coding by Aviad Golan @AviadGolan and Shai Rod @NightRang3r
 
+
 #!/usr/bin/env python
+
 
 import binascii as ba
 import time
@@ -20,37 +22,37 @@ device_pass = "00000000"
 ########## DO NOT CHANGE BYOND THIS LINE  ##########
 
 
-UDP_IP = "0.0.0.0"
-UDP_PORT = 20002
+UDP_IP = ""
+UDP_PORT = 10002
 
 id_list = []
 data_list = []
 
 
 def banner():
-	print """
+	print ("""
 		=========================================================
 	   	+ Switcher V2 Python                                    +
 	 	+ Reverse Engineering and Coding By:                    +
 	 	+ Aviad Golan (@AviadGolan) and Shai Rod (@NightRang3r) +
 	 	=========================================================	 
-"""
-	print "Usage:\r"
-	print "======\r"
-	print "Off command:" + " ./" + sys.argv[0] + " 0\r"
-	print "On command:" + " ./" + sys.argv[0] + " 1\r"
-	print "On command duration in minutes:" + " ./" + sys.argv[0] + " t30\r"
-	print "Get State:" + " ./" + sys.argv[0] + " 2\r"
-	print "Set Auto shutdown setting (in hours):" + " ./" + sys.argv[0] + " m03:00\r"
-	print "Retrieve Schedule from device:"  + " ./" + sys.argv[0] + " list\r"
-	print "Create a Schedule:" +  " ./" + sys.argv[0] + " create\r"
-	print "Delete Schedule from device:" + " ./" + sys.argv[0] + " del\r"
-	print "Enable Schedule:" + " ./" + sys.argv[0] + " enable\r"
-	print "Disable Schedule:" + " ./" + sys.argv[0] + " disable\r"
-	print "Change switcher name:" " ./" + sys.argv[0] + " nNAME\r"
-	print "Auto detect Switcher IP Address and state:" + " ./" + sys.argv[0] + " discover\r"
-	print "Configure Switcher in AP Mode:" + " ./" + sys.argv[0] + " configure\r"
-	print "Auto Extract the needed values for this script (device_id, phone_id and device_pass):" + " ./" + sys.argv[0] + " extract\r\n"
+""")
+	print ("Usage:\r")
+	print ("======\r")
+	print ("Off command:" + " ./" + sys.argv[0] + " 0\r")
+	print ("On command:" + " ./" + sys.argv[0] + " 1\r")
+	print ("On command duration in minutes:" + " ./" + sys.argv[0] + " t30\r")
+	print ("Get State:" + " ./" + sys.argv[0] + " 2\r")
+	print ("Set Auto shutdown setting (in hours):" + " ./" + sys.argv[0] + " m03:00\r")
+	print ("Retrieve Schedule from device:"  + " ./" + sys.argv[0] + " list\r")
+	print ("Create a Schedule:" +  " ./" + sys.argv[0] + " create\r")
+	print ("Delete Schedule from device:" + " ./" + sys.argv[0] + " del\r")
+	print ("Enable Schedule:" + " ./" + sys.argv[0] + " enable\r")
+	print ("Disable Schedule:" + " ./" + sys.argv[0] + " disable\r")
+	print ("Change switcher name:" + " ./" + sys.argv[0] + " nNAME\r")
+	print ("Auto detect Switcher IP Address and state:" + " ./" + sys.argv[0] + " discover\r")
+	print ("Configure Switcher in AP Mode:" + " ./" + sys.argv[0] + " configure\r")
+	print ("Auto Extract the needed values for this script (device_id, phone_id and device_pass):" + " ./" + sys.argv[0] + " extract\r\n")
 	sys.exit (1)
 
 if len (sys.argv) != 2:
@@ -88,10 +90,10 @@ else:
 
 # CRC 
 def crcSignFullPacketComKey(pData, pKey):
-	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(pData), 0x1021)))
+	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(pData), 0x1021))).decode()
 	pData = pData + crc[6:8] + crc[4:6]
-	crc = crc[6:8] + crc[4:6] + ba.hexlify( pKey )
-	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(crc), 0x1021)))
+	crc = crc[6:8] + crc[4:6] + ba.hexlify(pKey.encode() if isinstance(pKey, str) else pKey).decode()
+	crc = ba.hexlify(struct.pack('>I', ba.crc_hqx(ba.unhexlify(crc), 0x1021))).decode()
 	pData = pData + crc[6:8] + crc[4:6]
 	return pData
 
@@ -116,20 +118,20 @@ def sTime(res):
 	open_time = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
 	m, s = divmod(open_time, 60)
 	h, m = divmod(m, 60)
-	print "[*] Auto shutdown device in: %d:%02d:%02d" % (h, m, s)
+	print ("[*] Auto shutdown device in: %d:%02d:%02d" % (h, m, s))
 
 #  Generate auto shutdown time 
 def setAutoClose(hours):
 	h, m = hours.split(':')
 	mSeconds = int(h) * 3600 + int(m) * 60 
 	if mSeconds < 3600:
-		print "[!] Value Can't be less than 1 hour!"
+		print ("[!] Value Can't be less than 1 hour!")
 		sys.exit()
 	elif mSeconds > 86340:
-		print "[!] Value can't be more than 23 hours and 59 minutes!"
+		print ("[!] Value can't be more than 23 hours and 59 minutes!")
 		sys.exit()
 	else:
-		print "[+] Auto shutdown was set to " + str(hours) + " Hour(s)"
+		print ("[+] Auto shutdown was set to " + str(hours) + " Hour(s)")
 		return ba.hexlify(struct.pack('<I', mSeconds))
 
 def getAutoClose(res):
@@ -137,7 +139,7 @@ def getAutoClose(res):
 	open_time = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
 	m, s = divmod(open_time, 60)
 	h, m = divmod(m, 60)
-	print "[+] Device is configured to auto shutdown in: %d:%02d" % (h, m)  + " hour(s)"
+	print ("[+] Device is configured to auto shutdown in: %d:%02d" % (h, m)  + " hour(s)")
 	
 
 days = { 0x80:"Sun", 0x02:"Mon", 0x04:"Tue", 0x08:"Wed", 0x10:"Thu", 0x20:"Fri", 0x40:"Sat"}
@@ -158,29 +160,30 @@ def reverseInd(data):
 
 
 def GetSch(buffer, phone_id):
-	split_string = lambda x, n: [x[i:i+n] for i in range(0, len(x), n)]
+	def split_string(x, n):
+		return [x[i:i+n] for i in range(0, len(x), n)]
 	s = buffer[90:-8]
 	split = split_string(s,32)
 	if len(split) == 0:
-		print "[+] There are no entries on your Schedule"
+		print ("[+] There are no entries on your Schedule")
 		sys.exit()
 	else:
 		for i in range(len(split)):
-			print "\r"
-			print "[+] Schedule ID : " + str(int(split[i][0:2], 16))
+			print ("\r")
+			print ("[+] Schedule ID : " + str(int(split[i][0:2], 16)))
 			id_list.append(str(int(split[i][0:2], 16)))
 			if int(split[i][2:4], 16) == 0:
-				print "[+] Enabled: False"
+				print ("[+] Enabled: False")
 			elif int(split[i][2:4], 16) == 1:
-				print "[+] Enabled: True"
+				print ("[+] Enabled: True")
 			if split[i][4:6] == "00":
-				print "[+] Occurs: Once"
+				print ("[+] Occurs: Once")
 			elif split[i][4:6] == "fe":
-				print "[+] Occurs: Every Day"
+				print ("[+] Occurs: Every Day")
 			else:
-				print "[+] Days: " + getDays(bytearray(ba.unhexlify((split[i][4:6])))[0])
-			print "[+] Start time: " + reverseInd(split[i][8:16])
-			print "[+] End time: " + reverseInd(split[i][16:24])
+				print ("[+] Days: " + getDays(bytearray(ba.unhexlify((split[i][4:6])))[0]))
+			print ("[+] Start time: " + reverseInd(split[i][8:16]))
+			print ("[+] End time: " + reverseInd(split[i][16:24]))
 			time_id = split[i][0:2]
 			on_off = split[i][2:4]
 			week = split[i][4:6]
@@ -188,14 +191,14 @@ def GetSch(buffer, phone_id):
 			start_time = reverseInd(split[i][8:16])
 			end_time = reverseInd(split[i][16:24])
 			total_time=(datetime.datetime.strptime(end_time,'%H:%M') - datetime.datetime.strptime(start_time,'%H:%M'))
-			print "[+] Duration: " + str(total_time) + "\n"
+			print ("[+] Duration: " + str(total_time) + "\n")
 			start_time = split[i][8:16]
 			end_time = split[i][16:24]
 			data_list.append(time_id + on_off + week + timstate + start_time + end_time)
 
 
 def sigint_handler(signum, frame):
-	print '[+] Stopped...'
+	print ('[+] Stopped...')
 	sys.exit(0)
 
  
@@ -207,89 +210,93 @@ pKey = "00000000000000000000000000000000"
 ############# DO NOT CHANGE ############
 
 
-print """
+print ("""
 		=========================================================
 	   	+ Switcher V2 Python                                    +
 	 	+ Reverse Engineering and Coding By:                    +
 	 	+ Aviad Golan (@AviadGolan) and Shai Rod (@NightRang3r) +
 	 	=========================================================
-	 """
+	 """)
 if sys.argv[1] == "extract":
 	phone_id = "0000"  
 	device_pass = "00000000"
-	UDP_IP = "0.0.0.0"
-	UDP_PORT = 20002
+	UDP_IP = ""
+	UDP_PORT = 10002
 	sCommand = "0"
 	try:
-		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
+		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 		sock.bind((UDP_IP, UDP_PORT))
 		while True:
-			print "[*] Waiting for broadcast from Switcher device..."
+			print ("[*] Waiting for broadcast from Switcher device...")
 			data, addr = sock.recvfrom(1024) 
-			if ba.hexlify(data)[0:4] != "fef0" and len(data) != 165:
-					print "[!] Not a switcher broadcast message!"
+			print(f"[DEBUG] Received {len(data)} bytes from {addr[0]}")
+			if ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165:
+					print ("[!] Not a switcher broadcast message!")
+					continue
 			else:
-				b = ba.hexlify(data)[152:160]
+				b = ba.hexlify(data)[152:160].decode()
 				ip_addr = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
 				switcherIP = socket.inet_ntoa(struct.pack("<L", ip_addr))
-				device_id = ba.hexlify(data)[36:42]
+				device_id = ba.hexlify(data)[36:42].decode()
 				break
 
 	except Exception as e:
 		print("[!] Something went wrong...")
-		print "[!] " + str(e)
+		print ("[!] " + str(e))
 
 	try:
 		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		s.connect((switcherIP, 9957)) 
 		
-		data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
+		data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS().decode() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
 		data = crcSignFullPacketComKey(data, pKey)
 		print ("[*] Sending Login Packet to Switcher...")
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
-		pSession2 = ba.hexlify(res)[16:24]
+		pSession2 = ba.hexlify(res)[16:24].decode()
 		if not pSession2:
 			s.close()
 			print ("[!] Operation failed, Could not acquire SessionID, Please try again...")
 			sys.exit()
 		else:
-			data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00"
+			data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00"
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			print ("[+] Received SessionID: " + pSession2)
 			print ('\r\nInstructions:\r')
 			print ('\r\nOpen your Switcher App, perform one of the following actions and press the "Enter" key immediately:\r\n1. Click the "Update" button in the "Auto Shutdown" screen, or...\n2. Turn on device\n')
-			message  = raw_input('[+] Press the "Enter" key to continue...')
+			message  = input('[+] Press the "Enter" key to continue...')
 			print ("[*] Waiting for a valid Phone ID Packet...")
 			data = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			if len(res) != 87:
-				print "[!] Failed to get data, Please try again!"
+				print ("[!] Failed to get data, Please try again!")
 				s.close()
 				sys.exit()
 			else:
-				print "[+] Found Phone ID Packet!"
+				print ("[+] Found Phone ID Packet!")
 				brute_start = time.time()			
-				phone_id = ba.hexlify(res)[156:160]
+				phone_id = ba.hexlify(res)[156:160].decode()
 				for i in range(0, 9999):
-					device_pass = ba.hexlify("%04d"%(i))
+					device_pass = ba.hexlify(b"%04d"%(i)).decode()
 					sys.stdout.write("\r[*] Brute forcing Device Password, Please wait:" + device_pass)
 					sys.stdout.flush()
-					data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
+					data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
 					data = crcSignFullPacketComKey(data, pKey)
 					s.send(ba.unhexlify(data))
 					res = s.recv(1024)
 					if len(res) > 44 and len(res) < 60:
 						brute_end = time.time()
 						total_time= time.strftime("%H:%M:%S", time.gmtime(brute_end-brute_start))
-						print "\r\n[+] Found password in: " + total_time
-						print "[+] Switcher IP: " +  addr[0]
-						print "[+] Device ID: " + device_id
-						print "[+] Phone ID:" + phone_id
-						print "[+] Device Password: " + device_pass
+						print ("\r\n[+] Found password in: " + total_time)
+						print ("[+] Switcher IP: " +  addr[0])
+						print ("[+] Device ID: " + device_id)
+						print ("[+] Phone ID:" + phone_id)
+						print ("[+] Device Password: " + device_pass)
 						s.close()
 						file = open('switcher.txt', 'w') 
 						file.write("switcherIP = " +  '"' + addr[0] + '"\r')
@@ -297,65 +304,69 @@ if sys.argv[1] == "extract":
 						file.write("device_id = " + '"' + device_id + '"\r')
 						file.write("device_pass = " + '"' + device_pass + '"\r')
 						file.close() 
-						print "[+] Information was written to " + os.getcwd() + "/switcher.txt"
+						print ("[+] Information was written to " + os.getcwd() + "/switcher.txt")
 						sys.exit()
 	except Exception as e:
 		print("[!] Something went wrong...")
-		print "[!] " + str(e)
+		print ("[!] " + str(e))
 
 
 if sys.argv[1] == "discover":
 	try:
-		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
+		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 		sock.bind((UDP_IP, UDP_PORT))
 		while True:
-			print "[*] Waiting for broadcast from Switcher device...(Press CTRL+C to abort)"
-			data, addr = sock.recvfrom(1024) 
-			if ba.hexlify(data)[0:4] != "fef0" and len(data) != 165:
-				print "[!] Not a switcher broadcast message!"
+			print ("[*] Waiting for broadcast from Switcher device...(Press CTRL+C to abort)")
+			data, addr = sock.recvfrom(1024)
+			print(f"[DEBUG] Received {len(data)} bytes from {addr[0]}")
+			if ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165:
+				print ("[!] Not a switcher broadcast message!")
+				continue
 			else:
-				b = ba.hexlify(data)[152:160]
+				b = ba.hexlify(data)[152:160].decode()
 				ip_addr = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
-				print "[+] Switcher IP Address: " + socket.inet_ntoa(struct.pack("<L", ip_addr))
-				print "[+] Switcher MAC Address: " + ba.hexlify(data)[160:172].upper()
-				print "[+] Switcher Name: " + data[42:74]
-				print "[+] Device ID: " + ba.hexlify(data)[36:42]
-				if ba.hexlify(data)[266:270] == "0000":
-					print "[+] Device is OFF"
+				print ("[+] Switcher IP Address: " + socket.inet_ntoa(struct.pack("<L", ip_addr)))
+				print ("[+] Switcher MAC Address: " + ba.hexlify(data)[160:172].decode().upper())
+				print ("[+] Switcher Name: " + data[42:74].decode())
+				print ("[+] Device ID: " + ba.hexlify(data)[36:42].decode())
+				if ba.hexlify(data)[266:270].decode() == "0000":
+					print ("[+] Device is OFF")
 				else:
-					print "[+] Device is ON" 
-				b = ba.hexlify(data)[310:318]
+					print ("[+] Device is ON")
+				b = ba.hexlify(data)[310:318].decode()
 				open_time = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
-				imin = open_time / 60 % 60
-				ihour = open_time / 60 / 60
+				imin = open_time // 60 % 60
+				ihour = open_time // 60 // 60
 				isec = open_time - ((imin * 60) + (ihour * 3600))
-				print "[*] Device is set to auto shutdown in: " + (str(ihour) + " Hour(s) " + str(imin) + " Minute(s) " + str(isec) + " Second(s)")
+				print ("[*] Device is set to auto shutdown in: " + (str(ihour) + " Hour(s) " + str(imin) + " Minute(s) " + str(isec) + " Second(s)"))
 				
-				b = ba.hexlify(data)[294:302]
+				b = ba.hexlify(data)[294:302].decode()
 				open_time = int(b[6:8] + b[4:6] + b[2:4] + b[0:2] , 16)
 				m, s = divmod(open_time, 60)
 				h, m = divmod(m, 60)
-				print "[*] Auto shutdown device in: %d:%02d:%02d" % (h, m, s)
-				b = ba.hexlify(data)[270:278]
+				print ("[*] Auto shutdown device in: %d:%02d:%02d" % (h, m, s))
+				b = ba.hexlify(data)[270:278].decode()
 				i = int(b[2:4]+b[0:2], 16)
-				print "[+] Electric Current is: %.1f" % (i/float(220)) + "(A)\r\n" + "[+] Power consumption is: " + str(i) + "(W)\r\n"
+				print ("[+] Electric Current is: %.1f" % (i/float(220)) + "(A)\r\n" + "[+] Power consumption is: " + str(i) + "(W)\r\n")
 				
 	except Exception as e:
 		print("[!] Something went wrong...")
-		print "[!] " + str(e)
+		print ("[!] " + str(e))
 
 
 if sys.argv[1] == "configure":
-	print "\r\n****** WARNING ******\r"
-	print "\rUse this option to configure your switcher to work with this script/home assistant component only or if you don't have a smartphone or the switcher app/servers are no longer available, You won't be able to control it using the official switcher app unless you reset your switcher and reconfigure it using the app again!!!\r"
-	print "\r****** WARNING ******\r\n"
+	print ("\r\n****** WARNING ******\r")
+	print ("\rUse this option to configure your switcher to work with this script/home assistant component only or if you don't have a smartphone or the switcher app/servers are no longer available, You won't be able to control it using the official switcher app unless you reset your switcher and reconfigure it using the app again!!!\r")
+	print ("\r****** WARNING ******\r\n")
 	phone_id = "00000000"
 
 	completeFlag = False
 	while True and not completeFlag:	
-		message  = raw_input('Choose a Device Password: ')
+		message  = input('Choose a Device Password: ')
 		if ((not message and not completeFlag)) or ((len(message)) != 8) or not (message.isdigit()):
-			print "[!] Please enter an 8 digit password"
+			print ("[!] Please enter an 8 digit password")
 		else:
 			device_pass = message + "00000000000000000000000000000000000000000000000000000000"
 			admin_pass = device_pass
@@ -363,80 +374,84 @@ if sys.argv[1] == "configure":
 
 	completeFlag = False
 	while True and not completeFlag:	
-		message  = raw_input('Enter WiFi SSID: ')
+		message  = input('Enter WiFi SSID: ')
 		if ((not message and not completeFlag)) or ((len(message)) < 1):
-			print "[!] Please enter Wifi SSID"
+			print ("[!] Please enter Wifi SSID")
 		else:
-			ssid = ba.hexlify(message) + (32-len(message))*"00"
+			ssid = ba.hexlify(message.encode()).decode() + (32-len(message))*"00"
 			break
 
 	completeFlag = False
 	while True and not completeFlag:	
-		message  = raw_input('Enter WiFi Password: ')
+		message  = input('Enter WiFi Password: ')
 		if ((not message and not completeFlag)) or ((len(message)) < 8):
-			print "[!] Wifi Password needs to be at least 8 chars!"
+			print ("[!] Wifi Password needs to be at least 8 chars!")
 		else:
-			wifi_pass = ba.hexlify(message) + (32-len(message))*"00"
+			wifi_pass = ba.hexlify(message.encode()).decode() + (32-len(message))*"00"
 			break
 
-	print '\r\n*** Please make sure the switcher device is in ACCESS POINT MODE by holding the wifi configuration button on the switcher device for 10 seconds (until you see the blue led blinking fast) and that you are connected to the WiFi network "Switcher Boiler XXXX" ***\r\n'
-	message  = raw_input('If your switcher is in access point mode press enter to continue...')
+	print ('\r\n*** Please make sure the switcher device is in ACCESS POINT MODE by holding the wifi configuration button on the switcher device for 10 seconds (until you see the blue led blinking fast) and that you are connected to the WiFi network "Switcher Boiler XXXX" ***\r\n')
+	message  = input('If your switcher is in access point mode press enter to continue...')
 
 	try:
-		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
+		sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+		sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 		sock.bind((UDP_IP, UDP_PORT))
-		print "[*] Waiting for broadcast from Switcher device...(Press CTRL+C to abort)"
+		print ("[*] Waiting for broadcast from Switcher device...(Press CTRL+C to abort)")
 		while True:
-			data, addr = sock.recvfrom(1024) 
-			if (( ba.hexlify(data)[0:4] != "fef0" and len(data) != 165 )) or (( addr[0] != "192.168.1.1" )) or (( addr[0] != "192.168.4.1" )):
-				print "[!] Not a switcher configuration broadcast message!"
+			data, addr = sock.recvfrom(1024)
+			print(f"[DEBUG] Received {len(data)} bytes from {addr[0]}")
+			if (ba.hexlify(data)[0:4].decode() != "fef0" or len(data) != 165) or (addr[0] != "192.168.1.1" and addr[0] != "192.168.4.1"):
+				print ("[!] Not a switcher configuration broadcast message!")
+				continue
 			else:
-				b = ba.hexlify(data)[152:160]	 
+				b = ba.hexlify(data)[152:160].decode()
 				switcherIP = addr[0]
-				device_id = ba.hexlify(data)[36:42] + "000000"
-				print "[+] Switcher Access Point Address: " + addr[0]
-				print "[+] Device ID: " + ba.hexlify(data)[36:42]
+				device_id = ba.hexlify(data)[36:42].decode() + "000000"
+				print ("[+] Switcher Access Point Address: " + addr[0])
+				print ("[+] Device ID: " + ba.hexlify(data)[36:42].decode())
 				sock.close()
 				break
 	except Exception as e:
 		print("[!] Something went wrong...")
-		print "[!] " + str(e)
+		print ("[!] " + str(e))
 
 	try:
 		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		s.connect((switcherIP, 9957)) 
-		data = "fef0b1000232a20000000000340001000000" + device_id + getTS() + "00000000000000000000f0fe" + phone_id + device_pass + admin_pass + ssid + wifi_pass + "01"
+		data = "fef0b1000232a20000000000340001000000" + device_id + getTS().decode() + "00000000000000000000f0fe" + phone_id + device_pass + admin_pass + ssid + wifi_pass + "01"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
 		s.close()
-		print "[+] Phone ID: " + phone_id[0:4]
-		print "[+] Device password: " + device_pass[0:8]
+		print ("[+] Phone ID: " + phone_id[0:4])
+		print ("[+] Device password: " + device_pass[0:8])
 		file = open('switcher.txt', 'w') 
 		file.write("phone_id = " + '"' +  phone_id[0:4] + '"\r')
 		file.write("device_id = " + '"' + device_id[0:6]  + '"\r')
 		file.write("device_pass = " + '"' + device_pass[0:8] + '"\r')
 		file.close() 
-		print "[+] Information was written to " + os.getcwd() + "/switcher.txt"
+		print ("[+] Information was written to " + os.getcwd() + "/switcher.txt")
 		print ("[+] Done!")
 		s.close()
 		sys.exit()
 
 	except Exception as e:
 		print("[!] Something went wrong...")
-		print "[!] " + str(e)
+		print ("[!] " + str(e))
 
 
 try:
 	time.sleep(3)
 	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	s.connect((switcherIP, 9957)) 
-	data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
+	data = "fef052000232a100" + pSession + "340001000000000000000000"  + getTS().decode() + "00000000000000000000f0fe1c00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000"
 	data = crcSignFullPacketComKey(data, pKey)
 	print ("[*] Sending Login Packet to Switcher...")
 	s.send(ba.unhexlify(data))
 	res = s.recv(1024)
-	pSession2 = ba.hexlify(res)[16:24]
+	pSession2 = ba.hexlify(res)[16:24].decode()
 	if not pSession2:
 		s.close()
 		print ("[!] Operation failed, Could not acquire SessionID, Please try again...")
@@ -444,126 +459,125 @@ try:
 	else:
 		print ("[+] Received SessionID: " + pSession2)
 
-	data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00"
+	data = "fef0300002320103" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00"
 	data = crcSignFullPacketComKey(data, pKey)
 	print ("[*] Getting Switcher state...")
 	s.send(ba.unhexlify(data))
 	res = s.recv(1024)
-	print "[+] Device Name: " + res[40:72]
-	state = ba.hexlify(res)[150:154]
+	print ("[+] Device Name: " + res[40:72].decode())
+	state = ba.hexlify(res)[150:154].decode()
 	if sys.argv[1] == "0" and state == "0000":
 		s.close()
-		print "[+] Device is already OFF"
-		print getPower(res)
+		print (getPower(res))
 		sys.exit()
 	elif sys.argv[1] == "1" and state == "0100":
 		s.close()
-		print "[+] Device is already ON"
-		print getPower(res)
+		print ("[+] Device is already ON")
+		print (getPower(res))
 		sTime(res)
 		sys.exit()
 	elif sys.argv[1] == "2" and state == "0100":
 		s.close()
-		print "[+] Device is ON"
-		print getPower(res)
+		print ("[+] Device is ON")
+		print (getPower(res))
 		getAutoClose(res)
 		sTime(res)
 		sys.exit()
 	elif sys.argv[1] == "2" and state == "0000":
 		s.close()
-		print "[+] Device is OFF"
-		print getPower(res)
+		print ("[+] Device is OFF")
+		print (getPower(res))
 		getAutoClose(res)
 		sys.exit()
 	elif sys.argv[1].startswith('t'):
 		try:
 			sMinutes = int(sys.argv[1][1:])
-		except:
+		except ValueError:
 			print ("[!] " + sys.argv[1][1:] + " Is not a valid number!")
 			sys.exit()
 		if sMinutes > 0 and sMinutes <=60:
-			print "[+] Turning Switcher ON for " + str(sMinutes) + " minutes..."
-			data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "00"  + sTimer(sMinutes)
+			print ("[+] Turning Switcher ON for " + str(sMinutes) + " minutes...")
+			data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "00"  + sTimer(sMinutes).decode()
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			s.close()
 			print ("[+] Done!")
 		else:
-			print "[!] Enter a value between 1-60 minutes"
+			print ("[!] Enter a value between 1-60 minutes")
 			sys.exit()
 	elif sys.argv[1].startswith('m'):
 		if not hourRe.match(sys.argv[1][1:]):
-			print "[!] Please enter a value between 01:00 - 23:59"
+			print ("[!] Please enter a value between 01:00 - 23:59")
 			sys.exit()
 	
 		else:
 			auto_close = setAutoClose(sys.argv[1][1:])
-			data ="fef05b0002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000040400" + auto_close
+			data ="fef05b0002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000040400" + auto_close.decode()
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			s.close()
 	elif sys.argv[1] == "list":
-		print "[*] Retrieving schedule from device..."
-		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
+		print ("[*] Retrieving schedule from device...")
+		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
-		GetSch(ba.hexlify(res), phone_id + "0000")
+		GetSch(ba.hexlify(res).decode(), phone_id + "0000")
 		s.close()
 	elif sys.argv[1] == "del":
-		print "[*] Retrieving schedule from device..."
-		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
+		print ("[*] Retrieving schedule from device...")
+		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
-		GetSch(ba.hexlify(res), phone_id + "0000")
+		GetSch(ba.hexlify(res).decode(), phone_id + "0000")
 		
 		completeFlag = False
 		while True and not completeFlag:	
-			message  = raw_input('Enter The Schedule ID you want to Delete: ')
+			message  = input('Enter The Schedule ID you want to Delete: ')
 			if not message and not completeFlag:
-				print "[!] Please enter a valid ID"
+				print ("[!] Please enter a valid ID")
 			else:
 				if message not in id_list:
-					print "[!] ID does not exist"
+					print ("[!] ID does not exist")
 				else:
 					completeFlag = True
 					sch_id = "0" + message
-					data = "fef0580002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000080100" + sch_id
+					data = "fef0580002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000080100" + sch_id
 					data = crcSignFullPacketComKey(data, pKey)
 					s.send(ba.unhexlify(data))
 					res = s.recv(1024)
 					s.close()
-					print "[+] Entry " + message + " has been deleted"
+					print ("[+] Entry " + message + " has been deleted")
 					print ("[+] Done!")
 	
 	elif sys.argv[1] == "create":
 
-		print "[*] Retrieving schedule from device..."
-		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
+		print ("[*] Retrieving schedule from device...")
+		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
-		if int(ba.hexlify(res[44:45]),16) == 8:
-			print "[!] You can't create more than 8 entries"
+		if int(ba.hexlify(res[44:45]).decode(),16) == 8:
+			print ("[!] You can't create more than 8 entries")
 			s.close()
 			sys.exit()
 
 		all_days = []
 		
 		day_of_week = { "sun":128, "mon":2, "tue":4, "wed":8, "thu":16, "fri":32, "sat":64, "all":254, "once":0 }
-		print '\r\nEnter a day you would like to schedule and type "exit" or press the enter key when finished\r'
-		print "Available options: sun, mon, tue, wed, thu, fri, sat\r"
-		print 'Or use: "all" to select all days or "once" for one time only schedule\r' 
+		print ('\r\nEnter a day you would like to schedule and type "exit" or press the enter key when finished\r')
+		print ("Available options: sun, mon, tue, wed, thu, fri, sat\r")
+		print ('Or use: "all" to select all days or "once" for one time only schedule\r')
 		completeFlag = False
 		while True:
-			s_days = raw_input('Enter day: ')
+			s_days = input('Enter day: ')
 			if (((not s_days and completeFlag)) or (s_days == "exit" and completeFlag)):
 				break
 			elif s_days not in day_of_week:
-				print "[!] Please enter a valid value"
+				print ("[!] Please enter a valid value")
 			else:
 				all_days.append(day_of_week[s_days])
 				completeFlag = True
@@ -571,79 +585,79 @@ try:
 		
 		completeFlag = False
 		while True and not completeFlag:
-			start_time = raw_input('Enter start time (HH:MM): ')
+			start_time = input('Enter start time (HH:MM): ')
 			if (not start_time or not hourRe.match(start_time)):
-				print "[!] Please enter a valid value"
+				print ("[!] Please enter a valid value")
 			else:
 				completeFlag = True
 				start_time = time.mktime(time.strptime(time.strftime("%d/%m/%Y") + ' ' + start_time, "%d/%m/%Y %H:%M"))  
-				start_time = ba.hexlify(struct.pack('<I', int(start_time)))
+				start_time = ba.hexlify(struct.pack('<I', int(start_time))).decode()
 			
 		completeFlag = False
 		while True and not completeFlag:
-			end_time = raw_input('Enter end time (HH:MM): ')
+			end_time = input('Enter end time (HH:MM): ')
 			if (not end_time or not hourRe.match(end_time)):
-				print "[!] Please enter a valid value"
+				print ("[!] Please enter a valid value")
 			else:
 				completeFlag = True
 				end_time = time.mktime(time.strptime(time.strftime("%d/%m/%Y") + ' ' + end_time, "%d/%m/%Y %H:%M")) 
-				end_time = ba.hexlify(struct.pack('<I', int(end_time)))
-		print "[+] Schedule request sent to device..."
+				end_time = ba.hexlify(struct.pack('<I', int(end_time))).decode()
+		print ("[+] Schedule request sent to device...")
 		on_off = "01" # enabled / disabled
 		week = "%02x" % (int(sum(all_days)))
 		timstate = "01" 
 		start_time = start_time
 		end_time = end_time
-		data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000030c00ff" + on_off + week + timstate + start_time + end_time
+		data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000030c00ff" + on_off + week + timstate + start_time + end_time
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
 		s.close()
-		print "[+] Done!"
+		print ("[+] Done!")
 	
 	elif sys.argv[1].startswith('n'):
 		if len(sys.argv[1][1:]) > 32 or len(sys.argv[1][1:]) < 1:
-			print "[!] You must enter a minimum string of 1 char maximum 64 chars"
+			print ("[!] You must enter a minimum string of 1 char maximum 64 chars")
 			sys.exit()
 		else:
-			print "[*] Changing device name from " + res[40:72] + " to: " + sys.argv[1][1:]
-			switcher_name = ba.hexlify(sys.argv[1][1:]) + (32-len(sys.argv[1][1:]))*"00"
-			data = "fef0740002320202" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000" + switcher_name
+			print ("[*] Changing device name from " + res[40:72].decode() + " to: " + sys.argv[1][1:])
+			switcher_name = ba.hexlify(sys.argv[1][1:].encode()).decode() + (32-len(sys.argv[1][1:]))*"00"
+			data = "fef0740002320202" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000" + switcher_name
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
 			s.close()
-			print "[+] Done!"
+			print ("[+] Done!")
 	elif sys.argv[1] == "enable":
-		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
+		data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
 		data = crcSignFullPacketComKey(data, pKey)
 		s.send(ba.unhexlify(data))
 		res = s.recv(1024)
-		GetSch(ba.hexlify(res), phone_id + "0000")
+		GetSch(ba.hexlify(res).decode(), phone_id + "0000")
 		completeFlag = False
 		while True and not completeFlag:	
-			message  = raw_input('Enter The Schedule ID you want to enable (type "exit" to exit): ')
+			message  = input('Enter The Schedule ID you want to enable (type "exit" to exit): ')
 			if message == "exit":
-				print "[+] Done!"
+				print ("[+] Done!")
 				break	
 			if not message and not completeFlag:
-				print "[!] Please enter a valid ID"	
+				print ("[!] Please enter a valid ID")
 			else:
 				if message not in id_list:
-					print "[!] ID does not exist"
+					print ("[!] ID does not exist")
 				else:
 					sch_data = data_list[int(message)]
 					time_id = data_list[int(message)][0:2]
 					on_off = data_list[int(message)][2:4]
 					if on_off== "01":
-						print "[!] Schedule is already Enabled"
+						print ("[!] Schedule is already Enabled")
 					else:
 						on_off = "01"
 						week = data_list[int(message)][4:6]
 						timstate = data_list[int(message)][6:8]
 						start_time = data_list[int(message)][8:16]
 						end_time = data_list[int(message)][16:24]
-						data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000070c00" + time_id + on_off + week + timstate + start_time + end_time
+						data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000070c00" + time_id + on_off + week + timstate + start_time + end_time
 						data = crcSignFullPacketComKey(data, pKey)
 						s.send(ba.unhexlify(data))
 						res = s.recv(1024)
@@ -651,35 +665,35 @@ try:
 						sys.exit()
 						print ("[+] Done!")
 	elif sys.argv[1] == "disable":
-			data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
+			data = "fef0570002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000060000"
 			data = crcSignFullPacketComKey(data, pKey)
 			s.send(ba.unhexlify(data))
 			res = s.recv(1024)
-			GetSch(ba.hexlify(res), phone_id + "0000")
+			GetSch(ba.hexlify(res).decode(), phone_id + "0000")
 			completeFlag = False
 			while True and not completeFlag:	
-				message  = raw_input('Enter The Schedule ID you want to disable (type "exit" to exit): ')
+				message  = input('Enter The Schedule ID you want to disable (type "exit" to exit): ')
 				if message == "exit":
-					print "[+] Done!"
+					print ("[+] Done!")
 					break	
 				if not message and not completeFlag:
-					print "[!] Please enter a valid ID"	
+					print ("[!] Please enter a valid ID")
 				else:
 					if message not in id_list:
-						print "[!] ID does not exist"
+						print ("[!] ID does not exist")
 					else:
 						sch_data = data_list[int(message)]
 						time_id = data_list[int(message)][0:2]
 						on_off = data_list[int(message)][2:4]
 						if on_off== "00":
-							print "[!] Schedule is already Disabled"
+							print ("[!] Schedule is already Disabled")
 						else:
 							on_off = "00"
 							week = data_list[int(message)][4:6]
 							timstate = data_list[int(message)][6:8]
 							start_time = data_list[int(message)][8:16]
 							end_time = data_list[int(message)][16:24]
-							data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000070c00" + time_id + on_off + week + timstate + start_time + end_time
+							data = "fef0630002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "00000000000000000000000000000000000000000000000000000000070c00" + time_id + on_off + week + timstate + start_time + end_time
 							data = crcSignFullPacketComKey(data, pKey)
 							s.send(ba.unhexlify(data))
 							res = s.recv(1024)
@@ -687,7 +701,7 @@ try:
 							sys.exit()
 							print ("[+] Done!")
 	else:
-		data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
+		data = "fef05d0002320102" + pSession2 + "340001000000000000000000" + getTS().decode() + "00000000000000000000f0fe" + device_id + "00" + phone_id + "0000" + device_pass + "000000000000000000000000000000000000000000000000000000000106000" + sCommand + "0000000000"
 		data = crcSignFullPacketComKey(data, pKey)
 		if sCommand == "0":
 			print ("[*] Sending OFF Command to Switcher...")
@@ -703,4 +717,4 @@ except SystemExit:
     print("[+] Done!\r\n")
 except Exception as e:
 	print("[!] Something went wrong...")
-	print "[!] " + str(e)
+	print ("[!] " + str(e))


### PR DESCRIPTION
Major changes:
- Convert all Python 2 syntax to Python 3 (print statements, input(), division)
- Fix bytes/string handling throughout codebase (add .decode() for hexlify results)
- Fix UDP broadcast reception on macOS
  * Add SO_BROADCAST and SO_REUSEADDR socket options
  * Change UDP_PORT from 20002 to 10002 (correct port for Switcher broadcasts)
  * Update UDP_IP binding from "0.0.0.0" to "" for better broadcast compatibility
- Fix packet validation logic (change 'and' to 'or' for proper rejection)
- Add continue statements to skip invalid packets
- Add debug output to troubleshoot packet reception

Code quality improvements:
- Fix bare except clause (specify ValueError)
- Convert lambda to def function